### PR TITLE
Refactor Stats Command Test

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -357,7 +357,7 @@ You can test yourself with a flashcard containing open-ended question by specify
     :bulb: Answer is <b>case insensitive</b>.
     </div>
     <div markdown="block" class="alert alert-danger">
-    The index <b>must be a positive integer</b> 1, 2, 3, ...
+    :exclamation: The index <b>must be a positive integer</b> 1, 2, 3, ...
     </div>
 
     ![TestOpenStep2](./images/TestOpenStep2.png)
@@ -383,7 +383,7 @@ You can also test yourself a flashcard containing a multiple choice question by 
 3. Using the indices of the previous displayed list, enter the `test` command followed by the index of the flashcard you want to test and what you think the answer to the question is. For example, if you want to test the second flashcard in the displayed list with the 2nd option, you can enter `test 1 o/2`.
 
     <div markdown="block" class="alert alert-danger">
-    The index and option <b>must both be a positive integer</b> 1, 2, 3, ...
+    :exclamation: The index and option <b>must both be a positive integer</b> 1, 2, 3, ...
     </div>
 
     ![TestMCQStep3](./images/TestMCQStep3.png)

--- a/src/test/java/quickcache/logic/commands/StatsCommandTest.java
+++ b/src/test/java/quickcache/logic/commands/StatsCommandTest.java
@@ -73,15 +73,7 @@ public class StatsCommandTest {
 
         List<Flashcard> flashcardList = expectedModel.getFilteredFlashcardList();
 
-        int timesTested = 0;
-        int timesTestedCorrect = 0;
-
-        for (Flashcard flashcard : flashcardList) {
-            Statistics statistics = flashcard.getStatistics();
-            timesTested += statistics.getTimesTested();
-            timesTestedCorrect += statistics.getTimesTestedCorrect();
-        }
-        Statistics expectedStatistics = new Statistics(timesTested, timesTestedCorrect);
+        Statistics expectedStatistics = getStatisticsFromFlashcardList(flashcardList);
 
         assertCommandSuccess(statsCommand, model, expectedMessage, expectedModel, expectedStatistics);
     }
@@ -102,10 +94,7 @@ public class StatsCommandTest {
 
         List<Flashcard> flashcardList = expectedModel.getFilteredFlashcardList();
 
-        int timesTested = 0;
-        int timesTestedCorrect = 0;
-
-        Statistics expectedStatistics = new Statistics(timesTested, timesTestedCorrect);
+        Statistics expectedStatistics = getStatisticsFromFlashcardList(flashcardList);
 
         assertCommandSuccess(statsCommand, model, expectedMessage, expectedModel, expectedStatistics);
     }
@@ -130,5 +119,18 @@ public class StatsCommandTest {
 
         // different stats command -> returns false
         assertFalse(statsFirstCommand.equals(statsSecondCommand));
+    }
+
+    private Statistics getStatisticsFromFlashcardList(List<Flashcard> flashcardList) {
+        int timesTested = 0;
+        int timesTestedCorrect = 0;
+
+        for (Flashcard flashcard : flashcardList) {
+            Statistics statistics = flashcard.getStatistics();
+            timesTested += statistics.getTimesTested();
+            timesTestedCorrect += statistics.getTimesTestedCorrect();
+        }
+
+        return new Statistics(timesTested, timesTestedCorrect);
     }
 }

--- a/src/test/java/quickcache/logic/commands/StatsCommandTest.java
+++ b/src/test/java/quickcache/logic/commands/StatsCommandTest.java
@@ -7,11 +7,9 @@ import static quickcache.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static quickcache.logic.commands.CommandTestUtil.showFlashcardAtIndex;
 import static quickcache.testutil.TypicalFlashcards.getTypicalQuickCache;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +19,6 @@ import quickcache.model.Model;
 import quickcache.model.ModelManager;
 import quickcache.model.UserPrefs;
 import quickcache.model.flashcard.Flashcard;
-import quickcache.model.flashcard.FlashcardContainsTagPredicate;
 import quickcache.model.flashcard.FlashcardPredicate;
 import quickcache.model.flashcard.Question;
 import quickcache.model.flashcard.Statistics;
@@ -64,7 +61,7 @@ public class StatsCommandTest {
     public void execute_validTag_success() {
         Set<Tag> tagsToMatch = new HashSet<>();
         tagsToMatch.add(TypicalTags.TEST_TAG);
-        FlashcardPredicate flashcardPredicate = prepareFlashcardPredicate(tagsToMatch);
+        FlashcardPredicate flashcardPredicate = FlashcardPredicate.prepareOnlyTagsFlashcardPredicate(tagsToMatch);
 
         StatsCommand statsCommand = new StatsCommand(flashcardPredicate, tagsToMatch);
 
@@ -93,7 +90,7 @@ public class StatsCommandTest {
     public void execute_invalidTag_success() {
         Set<Tag> tagsToMatch = new HashSet<>();
         tagsToMatch.add(TypicalTags.INVALID_TAG);
-        FlashcardPredicate flashcardPredicate = prepareFlashcardPredicate(tagsToMatch);
+        FlashcardPredicate flashcardPredicate = FlashcardPredicate.prepareOnlyTagsFlashcardPredicate(tagsToMatch);
 
         StatsCommand statsCommand = new StatsCommand(flashcardPredicate, tagsToMatch);
 
@@ -111,12 +108,6 @@ public class StatsCommandTest {
         Statistics expectedStatistics = new Statistics(timesTested, timesTestedCorrect);
 
         assertCommandSuccess(statsCommand, model, expectedMessage, expectedModel, expectedStatistics);
-    }
-
-    private FlashcardPredicate prepareFlashcardPredicate(Set<Tag> tagsToMatch) {
-        ArrayList<Predicate<Flashcard>> predicates = new ArrayList<>();
-        predicates.add(new FlashcardContainsTagPredicate(tagsToMatch));
-        return new FlashcardPredicate(predicates);
     }
 
     @Test


### PR DESCRIPTION
Removes duplicate code fragment and uses `FlashcardPredicate#prepareOnlyTagsFlashcardPredicate` that @joshtyf has kindly created.