### PR TITLE
Bug fix: edit command parser

### DIFF
--- a/src/main/java/quickcache/logic/parser/EditCommandParser.java
+++ b/src/main/java/quickcache/logic/parser/EditCommandParser.java
@@ -9,7 +9,6 @@ import java.util.Set;
 
 import quickcache.commons.core.Messages;
 import quickcache.commons.core.index.Index;
-import quickcache.logic.commands.AddMultipleChoiceQuestionCommand;
 import quickcache.logic.commands.EditCommand;
 import quickcache.logic.parser.exceptions.ParseException;
 import quickcache.model.flashcard.Choice;

--- a/src/main/java/quickcache/logic/parser/EditCommandParser.java
+++ b/src/main/java/quickcache/logic/parser/EditCommandParser.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import quickcache.commons.core.Messages;
 import quickcache.commons.core.index.Index;
+import quickcache.logic.commands.AddMultipleChoiceQuestionCommand;
 import quickcache.logic.commands.EditCommand;
 import quickcache.logic.parser.exceptions.ParseException;
 import quickcache.model.flashcard.Choice;
@@ -94,8 +95,13 @@ public class EditCommandParser implements Parser<EditCommand> {
         if (choices.isEmpty()) {
             return Optional.empty();
         }
-        Collection<String> tagSet = choices.size() == 1 && choices.contains("") ? Collections.emptySet() : choices;
-        return Optional.of(ParserUtil.parseChoices(tagSet));
+
+        if (choices.size() == 1 && choices.contains("")) {
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    EditCommand.MESSAGE_USAGE));
+        }
+
+        return Optional.of(ParserUtil.parseChoices(choices));
     }
 
 }


### PR DESCRIPTION
When the user input is `edit [index] c/`, the error message shown was for addmcq command instead of edit command. I've changed the logic to handle this error better.